### PR TITLE
Allow deletionof Tasks

### DIFF
--- a/FreeRTOS-Cpp/include/FreeRTOS/EventGroups.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/EventGroups.hpp
@@ -56,8 +56,6 @@ class EventGroupBase {
   static void* operator new[](size_t, void* ptr) { return ptr; }
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   // NOLINTNEXTLINE
   using EventBits = std::bitset<((configUSE_16_BIT_TICKS == 1) ? 8 : 24)>;

--- a/FreeRTOS-Cpp/include/FreeRTOS/EventGroups.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/EventGroups.hpp
@@ -378,7 +378,21 @@ class EventGroupBase {
    * FreeRTOS::EventGroup or FreeRTOS::StaticEventGroup.
    */
   EventGroupBase() = default;
-  ~EventGroupBase() = default;
+
+  /**
+   * EventGroup.hpp
+   *
+   * @brief Destroy the EventGroupBase object by calling <tt>void
+   * vEventGroupDelete( EventGroupHandle_t xEventGroup )</tt>
+   *
+   * @see <https://www.freertos.org/vEventGroupDelete.html>
+   *
+   * Delete an event group.
+   *
+   * Tasks that are blocked on the event group being deleted will be unblocked,
+   * and report an event group value of 0.
+   */
+  ~EventGroupBase() { vEventGroupDelete(this->handle); };
 
   EventGroupBase(EventGroupBase&&) noexcept = default;
   EventGroupBase& operator=(EventGroupBase&&) noexcept = default;
@@ -423,21 +437,7 @@ class EventGroup : public EventGroupBase {
    * @include EventGroups/eventGroup.cpp
    */
   EventGroup() { this->handle = xEventGroupCreate(); }
-
-  /**
-   * EventGroup.hpp
-   *
-   * @brief Destroy the EventGroup object by calling <tt>void vEventGroupDelete(
-   * EventGroupHandle_t xEventGroup )</tt>
-   *
-   * @see <https://www.freertos.org/vEventGroupDelete.html>
-   *
-   * Delete an event group.
-   *
-   * Tasks that are blocked on the event group being deleted will be unblocked,
-   * and report an event group value of 0.
-   */
-  ~EventGroup() { vEventGroupDelete(this->handle); }
+  ~EventGroup() = default;
 
   EventGroup(const EventGroup&) = delete;
   EventGroup& operator=(const EventGroup&) = delete;

--- a/FreeRTOS-Cpp/include/FreeRTOS/MessageBuffer.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/MessageBuffer.hpp
@@ -389,7 +389,19 @@ class MessageBufferBase {
 
  private:
   MessageBufferBase() = default;
-  ~MessageBufferBase() = default;
+
+  /**
+   * MessageBuffer.hpp
+   *
+   * @brief Destroy the MessageBufferBase object by calling <tt>void
+   * vMessageBufferDelete( MessageBufferHandle_t xMessageBuffer )</tt>
+   *
+   * @see <https://www.freertos.org/vMessageBufferDelete.html>
+   *
+   * Delete a queue - freeing all the memory allocated for storing of items
+   * placed on the queue.
+   */
+  ~MessageBufferBase() { vMessageBufferDelete(this->handle); }
 
   MessageBufferBase(MessageBufferBase&&) noexcept = default;
   MessageBufferBase& operator=(MessageBufferBase&&) noexcept = default;
@@ -437,19 +449,7 @@ class MessageBuffer : public MessageBufferBase {
   explicit MessageBuffer(size_t size) {
     this->handle = xMessageBufferCreate(size);
   }
-
-  /**
-   * MessageBuffer.hpp
-   *
-   * @brief Destroy the MessageBuffer object by calling <tt>void
-   * vMessageBufferDelete( MessageBufferHandle_t xMessageBuffer )</tt>
-   *
-   * @see <https://www.freertos.org/vMessageBufferDelete.html>
-   *
-   * Delete a queue - freeing all the memory allocated for storing of items
-   * placed on the queue.
-   */
-  ~MessageBuffer() { vMessageBufferDelete(this->handle); }
+  ~MessageBuffer() = default;
 
   MessageBuffer(const MessageBuffer&) = delete;
   MessageBuffer& operator=(const MessageBuffer&) = delete;

--- a/FreeRTOS-Cpp/include/FreeRTOS/MessageBuffer.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/MessageBuffer.hpp
@@ -69,8 +69,6 @@ class MessageBufferBase {
   static void* operator new[](size_t, void* ptr) { return ptr; }
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   /**
    * MessageBuffer.hpp

--- a/FreeRTOS-Cpp/include/FreeRTOS/Mutex.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Mutex.hpp
@@ -59,8 +59,6 @@ class MutexBase {
   static void* operator new[](size_t, void* ptr) { return ptr; }
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   /**
    * Mutex.hpp
@@ -194,8 +192,6 @@ class RecursiveMutexBase : public MutexBase {
   static void* operator new[](size_t, void*);
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   /**
    * Mutex.hpp

--- a/FreeRTOS-Cpp/include/FreeRTOS/Mutex.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Mutex.hpp
@@ -157,7 +157,19 @@ class MutexBase {
 
  private:
   MutexBase() = default;
-  ~MutexBase() = default;
+
+  /**
+   * Mutex.hpp
+   *
+   * @brief Destroy the MutexBase object by calling <tt>void vSemaphoreDelete(
+   * SemaphoreHandle_t xSemaphore )</tt>
+   *
+   * @see <https://www.freertos.org/a00113.html#vSemaphoreDelete>
+   *
+   * @note Do not delete a mutex that has tasks blocked on it (tasks that are in
+   * the Blocked state waiting for the mutex to become available).
+   */
+  ~MutexBase() { vSemaphoreDelete(this->handle); }
 
   MutexBase(MutexBase&&) noexcept = default;
   MutexBase& operator=(MutexBase&&) noexcept = default;
@@ -294,19 +306,7 @@ class Mutex : public MutexBase {
    * @include Mutex/mutex.cpp
    */
   Mutex() { this->handle = xSemaphoreCreateMutex(); }
-
-  /**
-   * Mutex.hpp
-   *
-   * @brief Destroy the Mutex object by calling <tt>void vSemaphoreDelete(
-   * SemaphoreHandle_t xSemaphore )</tt>
-   *
-   * @see <https://www.freertos.org/a00113.html#vSemaphoreDelete>
-   *
-   * @note Do not delete a mutex that has tasks blocked on it (tasks that are in
-   * the Blocked state waiting for the mutex to become available).
-   */
-  ~Mutex() { vSemaphoreDelete(this->handle); }
+  ~Mutex() = default;
 
   Mutex(const Mutex&) = delete;
   Mutex& operator=(const Mutex&) = delete;
@@ -359,19 +359,7 @@ class RecursiveMutex : public RecursiveMutexBase {
    * @include Mutex/recursiveMutex.cpp
    */
   RecursiveMutex() { this->handle = xSemaphoreCreateRecursiveMutex(); }
-
-  /**
-   * Mutex.hpp
-   *
-   * @brief Destroy the RecursiveMutex object by calling <tt>void
-   * vSemaphoreDelete( SemaphoreHandle_t xSemaphore )</tt>
-   *
-   * @see <https://www.freertos.org/a00113.html#vSemaphoreDelete>
-   *
-   * @note Do not delete a mutex that has tasks blocked on it (tasks that are in
-   * the Blocked state waiting for the mutex to become available).
-   */
-  ~RecursiveMutex() { vSemaphoreDelete(this->handle); }
+  ~RecursiveMutex() = default;
 
   RecursiveMutex(const RecursiveMutex&) = delete;
   RecursiveMutex& operator=(const RecursiveMutex&) = delete;

--- a/FreeRTOS-Cpp/include/FreeRTOS/Queue.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Queue.hpp
@@ -608,7 +608,19 @@ class QueueBase {
    * FreeRTOS::Queue or FreeRTOS::StaticQueue.
    */
   QueueBase() = default;
-  ~QueueBase() = default;
+
+  /**
+   * Queue.hpp
+   *
+   * @brief Destroy the QueueBase object by calling <tt>void vQueueDelete(
+   * QueueHandle_t xQueue )</tt>
+   *
+   * @see <https://www.freertos.org/a00018.html#vQueueDelete>
+   *
+   * Delete a queue - freeing all the memory allocated for storing of items
+   * placed on the queue.
+   */
+  ~QueueBase() { vQueueDelete(this->handle); }
 
   QueueBase(QueueBase&&) noexcept = default;
   QueueBase& operator=(QueueBase&&) noexcept = default;
@@ -657,19 +669,7 @@ class Queue : public QueueBase<T> {
   explicit Queue(const UBaseType_t length) {
     this->handle = xQueueCreate(length, sizeof(T));
   }
-
-  /**
-   * Queue.hpp
-   *
-   * @brief Destroy the Queue object by calling <tt>void vQueueDelete(
-   * QueueHandle_t xQueue )</tt>
-   *
-   * @see <https://www.freertos.org/a00018.html#vQueueDelete>
-   *
-   * Delete a queue - freeing all the memory allocated for storing of items
-   * placed on the queue.
-   */
-  ~Queue() { vQueueDelete(this->handle); }
+  ~Queue() = default;
 
   Queue(const Queue&) = delete;
   Queue& operator=(const Queue&) = delete;

--- a/FreeRTOS-Cpp/include/FreeRTOS/Queue.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Queue.hpp
@@ -62,8 +62,6 @@ class QueueBase {
   static void* operator new[](size_t, void* ptr) { return ptr; }
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   /**
    * Queue.hpp

--- a/FreeRTOS-Cpp/include/FreeRTOS/Semaphore.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Semaphore.hpp
@@ -239,7 +239,19 @@ class SemaphoreBase {
 
  private:
   SemaphoreBase() = default;
-  ~SemaphoreBase() = default;
+
+  /**
+   * Semaphore.hpp
+   *
+   * @brief Destroy the SemaphoreBase object by calling <tt>void
+   * vSemaphoreDelete( SemaphoreHandle_t xSemaphore )</tt>
+   *
+   * @see <https://www.freertos.org/a00113.html#vSemaphoreDelete>
+   *
+   * @note Do not delete a semaphore that has tasks blocked on it (tasks that
+   * are in the Blocked state waiting for the semaphore to become available).
+   */
+  ~SemaphoreBase() { vSemaphoreDelete(this->handle); }
 
   SemaphoreBase(SemaphoreBase&&) noexcept = default;
   SemaphoreBase& operator=(SemaphoreBase&&) noexcept = default;
@@ -312,19 +324,7 @@ class BinarySemaphore : public SemaphoreBase {
    * @include Semaphore/binarySemaphore.cpp
    */
   BinarySemaphore() { this->handle = xSemaphoreCreateBinary(); }
-
-  /**
-   * Semaphore.hpp
-   *
-   * @brief Destroy the BinarySemaphore object by calling <tt>void
-   * vSemaphoreDelete( SemaphoreHandle_t xSemaphore )</tt>
-   *
-   * @see <https://www.freertos.org/a00113.html#vSemaphoreDelete>
-   *
-   * @note Do not delete a semaphore that has tasks blocked on it (tasks that
-   * are in the Blocked state waiting for the semaphore to become available).
-   */
-  ~BinarySemaphore() { vSemaphoreDelete(this->handle); }
+  ~BinarySemaphore() = default;
 
   BinarySemaphore(const BinarySemaphore&) = delete;
   BinarySemaphore& operator=(const BinarySemaphore&) = delete;
@@ -389,22 +389,7 @@ class CountingSemaphore : public SemaphoreBase {
                              const UBaseType_t initialCount = 0) {
     this->handle = xSemaphoreCreateCounting(maxCount, initialCount);
   }
-
-  /**
-   * Semaphore.hpp
-   *
-   * @brief Destroy the CountingSemaphore object by calling
-   * <tt>void vSemaphoreDelete( SemaphoreHandle_t xSemaphore )</tt>
-   *
-   * @see <https://www.freertos.org/a00113.html#vSemaphoreDelete>
-   *
-   * @note Do not delete a semaphore that has tasks blocked on it (tasks that
-   * are in the Blocked state waiting for the semaphore to become available).
-   *
-   * <b>Example Usage</b>
-   * @include Semaphore/countingSemaphore.cpp
-   */
-  ~CountingSemaphore() { vSemaphoreDelete(this->handle); }
+  ~CountingSemaphore() = default;
 
   CountingSemaphore(const CountingSemaphore&) = delete;
   CountingSemaphore& operator=(const CountingSemaphore&) = delete;

--- a/FreeRTOS-Cpp/include/FreeRTOS/Semaphore.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Semaphore.hpp
@@ -58,8 +58,6 @@ class SemaphoreBase {
   static void* operator new[](size_t, void* ptr) { return ptr; }
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   /**
    * Semaphore.hpp

--- a/FreeRTOS-Cpp/include/FreeRTOS/StreamBuffer.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/StreamBuffer.hpp
@@ -69,8 +69,6 @@ class StreamBufferBase {
   static void* operator new[](size_t, void* ptr) { return ptr; }
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   /**
    * StreamBuffer.hpp

--- a/FreeRTOS-Cpp/include/FreeRTOS/StreamBuffer.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/StreamBuffer.hpp
@@ -420,7 +420,18 @@ class StreamBufferBase {
 
  private:
   StreamBufferBase() = default;
-  ~StreamBufferBase() = default;
+
+  /**
+   * StreamBuffer.hpp
+   *
+   * @brief Destroy the StreamBufferBase object by calling
+   * <tt>void vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer )</tt>
+   *
+   * @see <https://www.freertos.org/vStreamBufferDelete.html>
+   *
+   * Deletes a stream buffer and free the allocated memory.
+   */
+  ~StreamBufferBase() { vStreamBufferDelete(this->handle); }
 
   StreamBufferBase(StreamBufferBase&&) noexcept = default;
   StreamBufferBase& operator=(StreamBufferBase&&) noexcept = default;
@@ -476,18 +487,7 @@ class StreamBuffer : public StreamBufferBase {
   explicit StreamBuffer(const size_t size, const size_t triggerLevel = 0) {
     this->handle = xStreamBufferCreate(size, triggerLevel);
   }
-
-  /**
-   * StreamBuffer.hpp
-   *
-   * @brief Destroy the StreamBuffer object by calling
-   * <tt>void vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer )</tt>
-   *
-   * @see <https://www.freertos.org/vStreamBufferDelete.html>
-   *
-   * Deletes a stream buffer and free the allocated memory.
-   */
-  ~StreamBuffer() { vStreamBufferDelete(this->handle); }
+  ~StreamBuffer() = default;
 
   StreamBuffer(const StreamBuffer&) = delete;
   StreamBuffer& operator=(const StreamBuffer&) = delete;

--- a/FreeRTOS-Cpp/include/FreeRTOS/Task.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Task.hpp
@@ -70,8 +70,6 @@ class TaskBase {
   static void* operator new[](size_t, void* ptr) { return ptr; }
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   enum class State {
     Running = eRunning,

--- a/FreeRTOS-Cpp/include/FreeRTOS/Task.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Task.hpp
@@ -1291,7 +1291,6 @@ class TaskBase {
 #endif /* INCLUDE_vTaskDelete */
   }
 
-
   /**
    * @brief Handle used to refer to the task when using the FreeRTOS interface.
    */

--- a/FreeRTOS-Cpp/include/FreeRTOS/Task.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Task.hpp
@@ -1252,10 +1252,45 @@ class TaskBase {
    * base class for creating a task.
    */
   TaskBase() = default;
-  ~TaskBase() = default;
 
   TaskBase(TaskBase&&) noexcept = default;
   TaskBase& operator=(TaskBase&&) noexcept = default;
+
+  /**
+   * Task.hpp
+   *
+   * @brief Destroy the Task object.
+   *
+   * @see <https://www.freertos.org/a00126.html>
+   *
+   * If INCLUDE_vTaskDelete is defined as 1 and the task handle is not NULL,
+   * then the destructor will call <tt>void vTaskDelete( TaskHandle_t xTask
+   * )</tt>  See the RTOS Configuration documentation for more information.
+   *
+   * Calling <tt>void vTaskDelete( TaskHandle_t xTask )</tt> will remove a task
+   * from the RTOS kernels management.  The task being deleted will be removed
+   * from all ready, blocked, suspended and event lists.
+   *
+   * @note The idle task is responsible for freeing the RTOS kernel allocated
+   * memory from tasks that have been deleted. It is therefore important that
+   * the idle task is not starved of microcontroller processing time if your
+   * application makes any calls to <tt>void vTaskDelete( TaskHandle_t xTask
+   * )</tt> Memory allocated by the task code is not automatically freed, and
+   * should be freed before the task is deleted.
+   *
+   * <b>Example Usage</b>
+   * @include Task/task.cpp
+   */
+  ~TaskBase() {
+#if (INCLUDE_vTaskDelete == 1)
+
+    if (handle != NULL) {
+      vTaskDelete(handle);
+    }
+
+#endif /* INCLUDE_vTaskDelete */
+  }
+
 
   /**
    * @brief Handle used to refer to the task when using the FreeRTOS interface.
@@ -1349,40 +1384,7 @@ class Task : public TaskBase {
                                            this, priority, &handle) == pdPASS);
   }
 
-  /**
-   * Task.hpp
-   *
-   * @brief Destroy the Task object.
-   *
-   * @see <https://www.freertos.org/a00126.html>
-   *
-   * If INCLUDE_vTaskDelete is defined as 1 and the task handle is not NULL,
-   * then the destructor will call <tt>void vTaskDelete( TaskHandle_t xTask
-   * )</tt>  See the RTOS Configuration documentation for more information.
-   *
-   * Calling <tt>void vTaskDelete( TaskHandle_t xTask )</tt> will remove a task
-   * from the RTOS kernels management.  The task being deleted will be removed
-   * from all ready, blocked, suspended and event lists.
-   *
-   * @note The idle task is responsible for freeing the RTOS kernel allocated
-   * memory from tasks that have been deleted. It is therefore important that
-   * the idle task is not starved of microcontroller processing time if your
-   * application makes any calls to <tt>void vTaskDelete( TaskHandle_t xTask
-   * )</tt> Memory allocated by the task code is not automatically freed, and
-   * should be freed before the task is deleted.
-   *
-   * <b>Example Usage</b>
-   * @include Task/task.cpp
-   */
-  ~Task() {
-#if (INCLUDE_vTaskDelete == 1)
-
-    if (handle != NULL) {
-      vTaskDelete(handle);
-    }
-
-#endif /* INCLUDE_vTaskDelete */
-  }
+  ~Task() = default;
 
   Task(Task&&) noexcept = default;
   Task& operator=(Task&&) noexcept = default;

--- a/FreeRTOS-Cpp/include/FreeRTOS/Timer.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Timer.hpp
@@ -65,8 +65,6 @@ class TimerBase {
   static void* operator new[](size_t, void* ptr) { return ptr; }
   static void* operator new(size_t) = delete;
   static void* operator new[](size_t) = delete;
-  static void operator delete(void*) = delete;
-  static void operator delete[](void*) = delete;
 
   /**
    * Timer.hpp


### PR DESCRIPTION
operator delete(void*) was deleted. This prevented deletion of any task. I don't see a reason for that, and no need to delete the operator.

Additionally, I think a StaticTask should be able to be removed.

For context: I have a device where devices can be added to an i2c bus, and later be removed. I want to handle that on a dynamically allocated task.