### PR TITLE
configUSE_TICKLESS_IDLE

### DIFF
--- a/FreeRTOS-Cpp/include/FreeRTOS/Kernel.hpp
+++ b/FreeRTOS-Cpp/include/FreeRTOS/Kernel.hpp
@@ -352,6 +352,7 @@ inline void suspendAll() { vTaskSuspendAll(); }
  */
 inline bool resumeAll() { return (xTaskResumeAll() == pdTRUE); }
 
+#if configUSE_TICKLESS_IDLE
 /**
  * Kernel.hpp
  *
@@ -372,6 +373,7 @@ inline bool resumeAll() { return (xTaskResumeAll() == pdTRUE); }
 inline void stepTick(const TickType_t ticksToJump) {
   vTaskStepTick(ticksToJump);
 }
+#endif
 
 /**
  * Kernel.hpp


### PR DESCRIPTION
Add a compilation guard condition around the stepTick function using the configUSE_TICKLESS_IDLE FreeRTOS flag.


Depending on the FreeRTOS config file configuration the vTaskStepTick function is not always defined. Since the stepTick function requires the configUSE_TICKLESS_IDLE to be set to 1 to function as intended it makes sense to add a guard compilation condition to prevent potential compilations issue